### PR TITLE
Add LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright © 2018-2020 Kohei Hasegawa and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
This creates an explicit LICENSE file. Reason: GitHub displays the license of a project in case a `LICENSE` file exists. See https://github.blog/2016-09-21-license-now-displayed-on-repository-overview/ for details.

With this PR, "MIT" should be displayed for this repository.

Even though there are currently no other code contributors, I just added the place holder "and contributors" to ensure that this works.

Oliver Kopp <oliver.kopp@mbition.io>, Mercedes-Benz AG on behalf of [MBition GmbH](https://mbition.io/).

[Imprint](https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md#mbition-gmbh)